### PR TITLE
Added video example for LazyImage

### DIFF
--- a/NukeDemo.xcodeproj/project.pbxproj
+++ b/NukeDemo.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		0CCF787F28A03BDC00C431E5 /* PulseUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0CCF787E28A03BDC00C431E5 /* PulseUI */; };
 		0CD878972431108200DE301A /* Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD878962431108200DE301A /* Images.swift */; };
 		0CE5F687215688590046609F /* PrefetchingDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE5F686215688590046609F /* PrefetchingDemoViewController.swift */; };
+		0ECDD86F2C746777007418F5 /* VideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDD86E2C746777007418F5 /* VideoView.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 /* End PBXBuildFile section */
@@ -68,6 +69,7 @@
 		0CCC18A7209EE341003D7172 /* AlamofireIntegrationDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireIntegrationDemoViewController.swift; sourceTree = "<group>"; };
 		0CD878962431108200DE301A /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		0CE5F686215688590046609F /* PrefetchingDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchingDemoViewController.swift; sourceTree = "<group>"; };
+		0ECDD86E2C746777007418F5 /* VideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoView.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* NukeDemo_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NukeDemo_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 				0CCC188F209EDCCF003D7172 /* Utilities.swift */,
 				0CD878962431108200DE301A /* Images.swift */,
 				0CC841A629CF532E0042A3A4 /* GIFImage.swift */,
+				0ECDD86E2C746777007418F5 /* VideoView.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -280,6 +283,7 @@
 				0CCC189C209EDCCF003D7172 /* MenuViewController.swift in Sources */,
 				0CD878972431108200DE301A /* Images.swift in Sources */,
 				0CCC1896209EDCCF003D7172 /* RateLimiterDemoViewController.swift in Sources */,
+				0ECDD86F2C746777007418F5 /* VideoView.swift in Sources */,
 				0CCC18A8209EE341003D7172 /* AlamofireIntegrationDemoViewController.swift in Sources */,
 				0CC841A729CF532E0042A3A4 /* GIFImage.swift in Sources */,
 				0CCC1898209EDCCF003D7172 /* DataCachingDemoViewController.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13,6 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidFinishLaunching(_ application: UIApplication) {
         window?.tintColor = UIColor.systemPink
         ImagePipeline.Configuration.isSignpostLoggingEnabled = true
+        
+        ImageDecoderRegistry.shared.register(ImageDecoders.Video.init)
 
         if #available(iOS 16, *) {
             print(URL.cachesDirectory)

--- a/Sources/Helpers/VideoView.swift
+++ b/Sources/Helpers/VideoView.swift
@@ -1,0 +1,22 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2024 Alexander Grebenyuk (github.com/kean).
+
+import AVFoundation
+import NukeVideo
+import SwiftUI
+
+struct VideoView: UIViewRepresentable {
+    
+    let asset: AVAsset
+    
+    func makeUIView(context: Context) -> VideoPlayerView {
+        let videoView = VideoPlayerView()
+        return videoView
+    }
+    
+    func updateUIView(_ videoView: VideoPlayerView, context: Context) {
+        videoView.asset = asset
+        videoView.play()
+    }
+}

--- a/Sources/LazyImageDemo.swift
+++ b/Sources/LazyImageDemo.swift
@@ -5,6 +5,7 @@
 import SwiftUI
 import Nuke
 import NukeUI
+import AVFoundation
 
 @MainActor
 struct LazyImageDemoView: View {
@@ -46,8 +47,10 @@ struct LazyImageDemoView: View {
     // This is where the image view is created.
     func makeImage(url: URL) -> some View {
         LazyImage(url: url) { state in
-            if let container = state.imageContainer, container.type ==  .gif, let data = container.data {
+            if let container = state.imageContainer, container.type == .gif, let data = container.data {
                 GIFImage(data: data)
+            } else if let container = state.imageContainer, container.type?.isVideo == true, let asset = container.userInfo[.videoAssetKey] as? AVAsset {
+                VideoView(asset: asset)
             } else if let image = state.image {
                 image
                     .resizable()
@@ -71,5 +74,6 @@ private let allItems = [
     Item(title: "Baseline JPEG", url: URL(string: "https://user-images.githubusercontent.com/1567433/120257591-80e2e580-c25e-11eb-8032-54f3a966aedb.jpeg")!),
     Item(title: "Progressive JPEG", url: URL(string: "https://user-images.githubusercontent.com/1567433/120257587-7fb1b880-c25e-11eb-93d1-7e7df2b9f5ca.jpeg")!),
     Item(title: "Animated GIF", url: URL(string: "https://cloud.githubusercontent.com/assets/1567433/6505557/77ff05ac-c2e7-11e4-9a09-ce5b7995cad0.gif")!),
+    Item(title: "MP4", url: URL(string: "https://kean.github.io/videos/cat_video.mp4")!),
     Item(title: "WebP", url: URL(string: "https://kean.github.io/images/misc/4.webp")!)
 ]


### PR DESCRIPTION
Since "out-of-the-box" video support was removed with Nuke 12, a demonstration on how to use videos with `LazyImage` is quite useful I think.